### PR TITLE
Implement ZIP support

### DIFF
--- a/internal/cfg/configuration.go
+++ b/internal/cfg/configuration.go
@@ -21,6 +21,7 @@ type (
 		Name string
 		Prefix string `toml:",omitempty"`
 		ExportFile []FileMap
+		ExportZip []ZipConfig
 		GroupDescription string `toml:",omitempty"`
 		Members []GroupMember
 		Tutor string `toml:",omitempty"`
@@ -30,6 +31,11 @@ type (
 	FileMap struct {
 		From string
 		To string
+	}
+
+	ZipConfig struct {
+		ArchiveFile string
+		Include []FileMap
 	}
 
 	GroupMember struct {


### PR DESCRIPTION
Add ZIP feature.

```toml
[[Courses.foo.ExportZip]]
  ArchiveFile = "archive-{{.X}}"
  [[Courses.foo.Include]]
    From = "foo.txt"
    To = "foo.{{.Ext}}"
  [[Courses.foo.Include]]
    From = "foo-{{.X}}.txt"
    To = "BAR"
```

## TODO
I need to implement some kind of file name "capturing".
e.g. `*.ipynb` should be exported to `foo-*.ipynb`.