### PR TITLE
templating: Add DateUtil

### DIFF
--- a/internal/cfg/configuration.go
+++ b/internal/cfg/configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/rabuu/uni-cli/internal/exit"
@@ -14,6 +15,7 @@ type Config struct {
 	ExportDirectory string
 	Semester string
 	Courses map[string]Course
+	DateFormat string
 }
 
 func ParseConfig(path string, uniDirectory string) Config {
@@ -41,6 +43,10 @@ func ParseConfig(path string, uniDirectory string) Config {
 
 	if config.Courses == nil {
 		config.Courses = make(map[string]Course)
+	}
+
+	if config.DateFormat == "" {
+		config.DateFormat = time.DateOnly
 	}
 
 	return config

--- a/internal/templating/data.go
+++ b/internal/templating/data.go
@@ -12,6 +12,7 @@ type TemplateData struct {
 	NumberPadded string
 	Config cfg.Config
 	Course cfg.Course
+	Date DateUtil
 }
 
 func Data(config *cfg.Config, courseId string, number int) TemplateData {
@@ -27,6 +28,7 @@ func Data(config *cfg.Config, courseId string, number int) TemplateData {
 		NumberPadded: dir.FormatWorkdirName(number, ""),
 		Config: *config,
 		Course: course,
+		Date: DateUtil{ format: config.DateFormat },
 	}
 
 	return data

--- a/internal/templating/dateutil.go
+++ b/internal/templating/dateutil.go
@@ -1,0 +1,47 @@
+package templating
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rabuu/uni-cli/internal/exit"
+)
+
+type DateUtil struct {
+	format string
+}
+
+func (util DateUtil) Today() (date string) {
+	now := time.Now()
+	date = now.Format(util.format)
+	return
+}
+
+func (util DateUtil) NextWeekday(day string, weekOffset int) (date string) {
+	now := time.Now()
+	weekday := weekdayFromString(day)
+
+	daysUntilWeekday := (int(weekday) - int(now.Weekday()) + 7) % 7
+
+	if daysUntilWeekday == 0 {
+		daysUntilWeekday = 7
+	}
+
+	t := now.AddDate(0, 0, daysUntilWeekday + (7 * weekOffset))
+	date = t.Format(util.format)
+	return
+}
+
+func weekdayFromString(day string) (weekday time.Weekday) {
+	switch strings.ToLower(day) {
+	case "monday": weekday = time.Monday
+	case "tuesday": weekday = time.Tuesday
+	case "wednesday": weekday = time.Wednesday
+	case "thursday": weekday = time.Thursday
+	case "friday": weekday = time.Friday
+	case "saturday": weekday = time.Saturday
+	case "sunday": weekday = time.Sunday
+	default: exit.ExitWithMsg("No valid weekday: " + day)
+	}
+	return
+}


### PR DESCRIPTION
This resolves #5.

I added `DateUtil` to our templating data. You can use it like so:
```
Today is {{.Date.Today}}.
Next Thursday is on {{.Date.NextWeekday "thurday" 0}}.
The Thursday after the next Thursday is on {{.Date.NextWeekday "thursday" 1}}.
```

I also added `DateFormat` to the main configuration. It is specified in [Go reference time format](https://pkg.go.dev/time#pkg-constants):
```toml
DateFormat = "02.01.2006"
```